### PR TITLE
Create issue number 20

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -4,13 +4,19 @@ FROM php:${VERSION}-cli-alpine
 
 WORKDIR /app
 
-RUN apk add --update linux-headers \
-    && apk --no-cache add  icu-libs \
-    && apk --no-cache add icu-data-full \
-    && apk --no-cache add icu-dev \
-    && apk --no-cache add pcre-dev ${PHPIZE_DEPS} \
-    && pecl install xdebug \
-    && apk del pcre-dev ${PHPIZE_DEPS}
+RUN set -eux; \
+    apk add --update linux-headers; \
+    apk --no-cache add icu-libs icu-data-full icu-dev; \
+    apk --no-cache add pcre-dev ${PHPIZE_DEPS}; \
+    PHP_MAJOR="${VERSION%%.*}"; \
+    if [ "${PHP_MAJOR}" -lt 8 ]; then \
+        XDEBUG_PACKAGE="xdebug-3.1.6"; \
+    else \
+        XDEBUG_PACKAGE="xdebug"; \
+    fi; \
+    pecl install "${XDEBUG_PACKAGE}"; \
+    docker-php-ext-enable xdebug; \
+    apk del pcre-dev ${PHPIZE_DEPS}
 
 RUN docker-php-ext-install -j$(nproc) bcmath intl
 


### PR DESCRIPTION
Add Xdebug version selection to Dockerfile to prevent incompatibility errors when building images with different PHP versions.

---
<a href="https://cursor.com/background-agent?bcId=bc-4ead6354-e4c8-44fb-a0d0-7e6080301c0e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-4ead6354-e4c8-44fb-a0d0-7e6080301c0e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds conditional Xdebug version selection based on PHP major and refactors Dockerfile install steps for reliability.
> 
> - **Dockerfile (`docker/Dockerfile`)**:
>   - **Xdebug installation**:
>     - Determines `PHP_MAJOR` from `VERSION` and installs `xdebug-3.1.6` for PHP < 8, otherwise `xdebug`.
>     - Explicitly enables Xdebug via `docker-php-ext-enable xdebug`.
>   - **Build robustness/refactor**:
>     - Uses `set -eux` and consolidates `apk` commands with `--no-cache`.
>     - Keeps `linux-headers`, ICU libs/dev, `pcre-dev` + `${PHPIZE_DEPS}` during build; removes them after.
>   - **Extensions/Tools**:
>     - Unchanged: installs `bcmath`, `intl`, and Composer 2.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 0861c1f28f22b4923d0738aa736859369b362036. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->